### PR TITLE
tostring() non-strings for protocol encoding

### DIFF
--- a/lredis/protocol.lua
+++ b/lredis/protocol.lua
@@ -3,7 +3,9 @@
 
 -- Encode a redis bulk string
 local function encode_bulk_string(str)
-	assert(type(str) == "string")
+	if type(str) ~= "string" then
+		str = tostring(str)
+	end
 	return string.format("$%d\r\n%s\r\n", #str, str)
 end
 


### PR DESCRIPTION
It's quite  a nuisance to need to `tostring()` all the numbers and whatever other non-strings there may be in  a command call when it can be done automatically, and the tostring() check is already present in the code.